### PR TITLE
Fix: Version specification of boto3 used in video-search-ai-agent-twelve-labs-via-bedrock

### DIFF
--- a/experiments/intelligent-video-search-ai-agent-twelve-labs-via-bedrock/lambdas/ExtractInsightsFunction/src/requirements.txt
+++ b/experiments/intelligent-video-search-ai-agent-twelve-labs-via-bedrock/lambdas/ExtractInsightsFunction/src/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.24.3
 opensearch-py>=2.3.0
 requests>=2.31.0
-boto3>=1.139.9
+boto3>=1.39.9


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update boto3 version to proper version in ExtractInsightsFunction of video-search-ai-agent-twelve-labs-via-bedrock.
The version specification indicates boto3=>1.139.9, and deployment cannot be done without fixing this.
