### PR TITLE
solved testing issues

### DIFF
--- a/agentic-football-sample-agents/ai-team-strands-balanced/deploy-all-windows.ps1
+++ b/agentic-football-sample-agents/ai-team-strands-balanced/deploy-all-windows.ps1
@@ -50,9 +50,9 @@ Write-Host ""
 # ============================================================
 Write-Host "Checking prerequisites..."
 
-$agentcorePath = (Get-Command agentcore -ErrorAction SilentlyContinue | Where-Object { $_.Source -match "npm|Roaming" } | Select-Object -First 1).Source
+$npmPrefix = npm config get prefix
+$agentcorePath = Join-Path $npmPrefix "agentcore.cmd"
 if (-not $agentcorePath) {
-    $agentcorePath = "C:\Users\$env:USERNAME\AppData\Roaming\npm\agentcore.cmd"
     if (-not (Test-Path $agentcorePath)) {
         Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
         exit 1
@@ -269,6 +269,23 @@ if ($deployExitCode -eq 0) {
 Write-Host "  Account: $awsAccountId"
 Write-Host "  Region:  $($env:AWS_DEFAULT_REGION)"
 Write-Host ""
+
+# List Agent ARNs
+if ($deployExitCode -eq 0) {
+    Write-Host "  Agent ARNs (copy these to the Player Portal):" -ForegroundColor Cyan
+    $ErrorActionPreference = "Continue"
+    $allRuntimes = aws bedrock-agentcore-control list-agent-runtimes --query "agentRuntimes[].{name:agentRuntimeName,arn:agentRuntimeArn}" --output json --region $env:AWS_DEFAULT_REGION 2>$null | ConvertFrom-Json
+    $ErrorActionPreference = "Stop"
+    foreach ($agent in $allAgents) {
+        $agentNameClean = ($agent -replace '-', '_') + "_agent"
+        $match = $allRuntimes | Where-Object { $_.name -eq "aiteam_$agentNameClean" }
+        if ($match) {
+            $displayName = $agent.ToUpper() -replace 'AI-',''
+            Write-Host "    $($displayName): $($match.arn)" -ForegroundColor White
+        }
+    }
+    Write-Host ""
+}
 
 # Cleanup
 Write-Host "Cleaning up build directory..."

--- a/agentic-football-sample-agents/ai-team-strands-extremely-aggressive/deploy-all-windows.ps1
+++ b/agentic-football-sample-agents/ai-team-strands-extremely-aggressive/deploy-all-windows.ps1
@@ -50,13 +50,11 @@ Write-Host ""
 # ============================================================
 Write-Host "Checking prerequisites..."
 
-$agentcorePath = (Get-Command agentcore -ErrorAction SilentlyContinue | Where-Object { $_.Source -match "npm|Roaming" } | Select-Object -First 1).Source
-if (-not $agentcorePath) {
-    $agentcorePath = "C:\Users\$env:USERNAME\AppData\Roaming\npm\agentcore.cmd"
-    if (-not (Test-Path $agentcorePath)) {
-        Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
-        exit 1
-    }
+$npmPrefix = npm config get prefix
+$agentcorePath = Join-Path $npmPrefix "agentcore.cmd"
+if (-not (Test-Path $agentcorePath)) {
+    Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
+    exit 1
 }
 Write-Host "  agentcore CLI: OK" -ForegroundColor Green
 
@@ -269,6 +267,23 @@ if ($deployExitCode -eq 0) {
 Write-Host "  Account: $awsAccountId"
 Write-Host "  Region:  $($env:AWS_DEFAULT_REGION)"
 Write-Host ""
+
+# List Agent ARNs
+if ($deployExitCode -eq 0) {
+    Write-Host "  Agent ARNs (copy these to the Player Portal):" -ForegroundColor Cyan
+    $ErrorActionPreference = "Continue"
+    $allRuntimes = aws bedrock-agentcore-control list-agent-runtimes --query "agentRuntimes[].{name:agentRuntimeName,arn:agentRuntimeArn}" --output json --region $env:AWS_DEFAULT_REGION 2>$null | ConvertFrom-Json
+    $ErrorActionPreference = "Stop"
+    foreach ($agent in $allAgents) {
+        $agentNameClean = "agg_" + ($agent -replace 'ai-', '') + "_agent"
+        $match = $allRuntimes | Where-Object { $_.name -eq "aiteamaggressive_$agentNameClean" }
+        if ($match) {
+            $displayName = $agent.ToUpper() -replace 'AI-',''
+            Write-Host "    $($displayName): $($match.arn)" -ForegroundColor White
+        }
+    }
+    Write-Host ""
+}
 
 # Cleanup
 Write-Host "Cleaning up build directory..."

--- a/agentic-football-sample-agents/ai-team-strands-extremely-defensive/deploy-all-windows.ps1
+++ b/agentic-football-sample-agents/ai-team-strands-extremely-defensive/deploy-all-windows.ps1
@@ -50,13 +50,11 @@ Write-Host ""
 # ============================================================
 Write-Host "Checking prerequisites..."
 
-$agentcorePath = (Get-Command agentcore -ErrorAction SilentlyContinue | Where-Object { $_.Source -match "npm|Roaming" } | Select-Object -First 1).Source
-if (-not $agentcorePath) {
-    $agentcorePath = "C:\Users\$env:USERNAME\AppData\Roaming\npm\agentcore.cmd"
-    if (-not (Test-Path $agentcorePath)) {
-        Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
-        exit 1
-    }
+$npmPrefix = npm config get prefix
+$agentcorePath = Join-Path $npmPrefix "agentcore.cmd"
+if (-not (Test-Path $agentcorePath)) {
+    Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
+    exit 1
 }
 Write-Host "  agentcore CLI: OK" -ForegroundColor Green
 
@@ -269,6 +267,23 @@ if ($deployExitCode -eq 0) {
 Write-Host "  Account: $awsAccountId"
 Write-Host "  Region:  $($env:AWS_DEFAULT_REGION)"
 Write-Host ""
+
+# List Agent ARNs
+if ($deployExitCode -eq 0) {
+    Write-Host "  Agent ARNs (copy these to the Player Portal):" -ForegroundColor Cyan
+    $ErrorActionPreference = "Continue"
+    $allRuntimes = aws bedrock-agentcore-control list-agent-runtimes --query "agentRuntimes[].{name:agentRuntimeName,arn:agentRuntimeArn}" --output json --region $env:AWS_DEFAULT_REGION 2>$null | ConvertFrom-Json
+    $ErrorActionPreference = "Stop"
+    foreach ($agent in $allAgents) {
+        $agentNameClean = "dfs_" + ($agent -replace 'ai-', '') + "_agent"
+        $match = $allRuntimes | Where-Object { $_.name -eq "aiteamdefensive_$agentNameClean" }
+        if ($match) {
+            $displayName = $agent.ToUpper() -replace 'AI-',''
+            Write-Host "    $($displayName): $($match.arn)" -ForegroundColor White
+        }
+    }
+    Write-Host ""
+}
 
 # Cleanup
 Write-Host "Cleaning up build directory..."

--- a/agentic-football-sample-agents/ai-team-strands-gateway/deploy-all-windows.ps1
+++ b/agentic-football-sample-agents/ai-team-strands-gateway/deploy-all-windows.ps1
@@ -58,13 +58,11 @@ Write-Host ""
 # ============================================================
 Write-Host "Checking prerequisites..."
 
-$agentcorePath = (Get-Command agentcore -ErrorAction SilentlyContinue | Where-Object { $_.Source -match "npm|Roaming" } | Select-Object -First 1).Source
-if (-not $agentcorePath) {
-    $agentcorePath = "C:\Users\$env:USERNAME\AppData\Roaming\npm\agentcore.cmd"
-    if (-not (Test-Path $agentcorePath)) {
-        Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
-        exit 1
-    }
+$npmPrefix = npm config get prefix
+$agentcorePath = Join-Path $npmPrefix "agentcore.cmd"
+if (-not (Test-Path $agentcorePath)) {
+    Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
+    exit 1
 }
 Write-Host "  agentcore CLI: OK" -ForegroundColor Green
 
@@ -444,7 +442,7 @@ Write-Host ""
 Write-Host "Attaching AgentCore Gateway permissions to execution roles..."
 
 $ErrorActionPreference = "Continue"
-$execRoles = (aws iam list-roles --query "Roles[?starts_with(RoleName, 'AmazonBedrockAgentCoreSDKRuntime-$($env:AWS_DEFAULT_REGION)-')].RoleName" --output text 2>$null)
+$execRoles = (aws iam list-roles --query "Roles[?starts_with(RoleName, 'AgentCore-aiteamgateway-')].RoleName" --output text 2>$null)
 $ErrorActionPreference = "Stop"
 
 if ($execRoles -and $execRoles.Trim()) {
@@ -480,6 +478,41 @@ if ($execRoles -and $execRoles.Trim()) {
 }
 
 # ============================================================
+# Set GATEWAY_URL environment variable on each runtime
+# (agentcore deploy via CDK does not pass environmentVariables from agentcore.json)
+# ============================================================
+Write-Host ""
+Write-Host "Setting GATEWAY_URL environment variable on deployed runtimes..."
+
+$runtimePrefix = "aiteamgateway"
+$envVarScript = @"
+import boto3, sys
+client = boto3.client('bedrock-agentcore-control', region_name='$($env:AWS_DEFAULT_REGION)')
+runtimes = client.list_agent_runtimes()['agentRuntimes']
+prefix = '$runtimePrefix'
+gateway_url = '$GATEWAY_URL'
+region = '$($env:AWS_DEFAULT_REGION)'
+updated = 0
+for rt in runtimes:
+    name = rt.get('agentRuntimeName', '')
+    if name.startswith(prefix + '_'):
+        rid = rt['agentRuntimeId']
+        r = client.get_agent_runtime(agentRuntimeId=rid)
+        client.update_agent_runtime(
+            agentRuntimeId=rid,
+            agentRuntimeArtifact=r['agentRuntimeArtifact'],
+            roleArn=r['roleArn'],
+            networkConfiguration=r['networkConfiguration'],
+            environmentVariables={'GATEWAY_URL': gateway_url, 'AWS_DEFAULT_REGION': region}
+        )
+        print(f'  Set GATEWAY_URL on: {name} ({rid})')
+        updated += 1
+if updated == 0:
+    print('  WARNING: No runtimes found with prefix ' + prefix)
+"@
+python -c $envVarScript
+
+# ============================================================
 # Summary
 # ============================================================
 Write-Host ""
@@ -500,6 +533,23 @@ Write-Host "  Account:  $awsAccountId"
 Write-Host "  Region:   $($env:AWS_DEFAULT_REGION)"
 Write-Host "  Gateway:  $GATEWAY_URL"
 Write-Host ""
+
+# List Agent ARNs
+if ($deployExitCode -eq 0) {
+    Write-Host "  Agent ARNs (copy these to the Player Portal):" -ForegroundColor Cyan
+    $ErrorActionPreference = "Continue"
+    $allRuntimes = aws bedrock-agentcore-control list-agent-runtimes --query "agentRuntimes[].{name:agentRuntimeName,arn:agentRuntimeArn}" --output json --region $env:AWS_DEFAULT_REGION 2>$null | ConvertFrom-Json
+    $ErrorActionPreference = "Stop"
+    foreach ($agent in $allAgents) {
+        $agentNameClean = ($agent -replace '-', '_') + "_agent"
+        $match = $allRuntimes | Where-Object { $_.name -eq "aiteamgateway_$agentNameClean" }
+        if ($match) {
+            $displayName = $agent.ToUpper() -replace 'AI-',''
+            Write-Host "    $($displayName): $($match.arn)" -ForegroundColor White
+        }
+    }
+    Write-Host ""
+}
 
 # Cleanup
 Write-Host "Cleaning up build directory..."

--- a/agentic-football-sample-agents/ai-team-strands-memory/deploy-all-windows.ps1
+++ b/agentic-football-sample-agents/ai-team-strands-memory/deploy-all-windows.ps1
@@ -50,13 +50,11 @@ Write-Host ""
 # ============================================================
 Write-Host "Checking prerequisites..."
 
-$agentcorePath = (Get-Command agentcore -ErrorAction SilentlyContinue | Where-Object { $_.Source -match "npm|Roaming" } | Select-Object -First 1).Source
-if (-not $agentcorePath) {
-    $agentcorePath = "C:\Users\$env:USERNAME\AppData\Roaming\npm\agentcore.cmd"
-    if (-not (Test-Path $agentcorePath)) {
-        Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
-        exit 1
-    }
+$npmPrefix = npm config get prefix
+$agentcorePath = Join-Path $npmPrefix "agentcore.cmd"
+if (-not (Test-Path $agentcorePath)) {
+    Write-Host "  ERROR: AgentCore CLI not found. Install: npm install -g @aws/agentcore" -ForegroundColor Red
+    exit 1
 }
 Write-Host "  agentcore CLI: OK" -ForegroundColor Green
 
@@ -311,7 +309,7 @@ Write-Host ""
 Write-Host "Attaching AgentCore Memory permissions to execution roles..."
 
 $ErrorActionPreference = "Continue"
-$execRoles = (aws iam list-roles --query "Roles[?starts_with(RoleName, 'AmazonBedrockAgentCoreSDKRuntime-$($env:AWS_DEFAULT_REGION)-')].RoleName" --output text 2>$null)
+$execRoles = (aws iam list-roles --query "Roles[?starts_with(RoleName, 'AgentCore-aiteammemory-')].RoleName" --output text 2>$null)
 $ErrorActionPreference = "Stop"
 
 if ($execRoles -and $execRoles.Trim()) {
@@ -353,6 +351,41 @@ if ($execRoles -and $execRoles.Trim()) {
 }
 
 # ============================================================
+# Set MEMORY_ID environment variable on each runtime
+# (agentcore deploy via CDK does not pass environmentVariables from agentcore.json)
+# ============================================================
+Write-Host ""
+Write-Host "Setting MEMORY_ID environment variable on deployed runtimes..."
+
+$runtimePrefix = "aiteammemory"
+$envVarScript = @"
+import boto3, sys
+client = boto3.client('bedrock-agentcore-control', region_name='$($env:AWS_DEFAULT_REGION)')
+runtimes = client.list_agent_runtimes()['agentRuntimes']
+prefix = '$runtimePrefix'
+memory_id = '$MEMORY_ID'
+region = '$($env:AWS_DEFAULT_REGION)'
+updated = 0
+for rt in runtimes:
+    name = rt.get('agentRuntimeName', '')
+    if name.startswith(prefix + '_'):
+        rid = rt['agentRuntimeId']
+        r = client.get_agent_runtime(agentRuntimeId=rid)
+        client.update_agent_runtime(
+            agentRuntimeId=rid,
+            agentRuntimeArtifact=r['agentRuntimeArtifact'],
+            roleArn=r['roleArn'],
+            networkConfiguration=r['networkConfiguration'],
+            environmentVariables={'MEMORY_ID': memory_id, 'AWS_DEFAULT_REGION': region}
+        )
+        print(f'  Set MEMORY_ID on: {name} ({rid})')
+        updated += 1
+if updated == 0:
+    print('  WARNING: No runtimes found with prefix ' + prefix)
+"@
+python -c $envVarScript
+
+# ============================================================
 # Summary
 # ============================================================
 Write-Host ""
@@ -373,6 +406,23 @@ Write-Host "  Account:  $awsAccountId"
 Write-Host "  Region:   $($env:AWS_DEFAULT_REGION)"
 Write-Host "  Memory:   $MEMORY_ID"
 Write-Host ""
+
+# List Agent ARNs
+if ($deployExitCode -eq 0) {
+    Write-Host "  Agent ARNs (copy these to the Player Portal):" -ForegroundColor Cyan
+    $ErrorActionPreference = "Continue"
+    $allRuntimes = aws bedrock-agentcore-control list-agent-runtimes --query "agentRuntimes[].{name:agentRuntimeName,arn:agentRuntimeArn}" --output json --region $env:AWS_DEFAULT_REGION 2>$null | ConvertFrom-Json
+    $ErrorActionPreference = "Stop"
+    foreach ($agent in $allAgents) {
+        $agentNameClean = ($agent -replace '-', '_') + "_agent"
+        $match = $allRuntimes | Where-Object { $_.name -eq "aiteammemory_$agentNameClean" }
+        if ($match) {
+            $displayName = $agent.ToUpper() -replace 'AI-',''
+            Write-Host "    $($displayName): $($match.arn)" -ForegroundColor White
+        }
+    }
+    Write-Host ""
+}
 
 # Cleanup
 Write-Host "Cleaning up build directory..."


### PR DESCRIPTION
*Description of changes:*
agentcorePath fix — uses npm config get prefix to locate the CLI reliably
Explicit agentcore create flags — --framework Strands --model-provider Bedrock --memory none (replaces broken --defaults)
CDK bootstrap improvements — checks for CDKToolkit stack status, cleans broken stacks before re-bootstrapping
ARN listing — prints each agent's ARN at the end of deployment for easy copy to Player Portal

Memory: MEMORY_ID post-deploy — uses boto3 to set environment variable on each runtime (CDK ignores environmentVariables from agentcore.json)
Memory: role search fix — searches AgentCore-aiteammemory-* roles for permission attachment

Gateway: GATEWAY_URL post-deploy — same boto3 approach as memory
Gateway: role search fix — searches AgentCore-aiteamgateway-* roles